### PR TITLE
atualizando openpyxl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ protoDadosjusbr>=0.7
 protobuf==3.18.0
 odfpy==1.4.1
 xlrd==2.0.1
-openpyxl==3.0.10
+openpyxl>=3.0.10


### PR DESCRIPTION
- erro no teste: `Pandas requires version '3.1.0' or newer of 'openpyxl' (version '3.0.10' currently installed).`