### PR TITLE
reorganizando os testes

### DIFF
--- a/src/parser_test.py
+++ b/src/parser_test.py
@@ -149,7 +149,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_01_2022, result_to_dict["contraCheque"][0])
 
-
     # Problemas com colunas nulas resultava em rubricas com valores incorretos
     def test_mprn_01_2021(self):
         self.maxDiff = None
@@ -165,12 +164,11 @@ class TestParser(unittest.TestCase):
         dados = data.Data("2021", "01", "MPRN", "src/output_test/sheets")
         dados = data.load(files, dados)
         result_data = parse(dados, "mprn/01/2021")
-        
+
         # Converto o resultado do parser, em dict
         result_to_dict = MessageToDict(result_data)
 
         self.assertEqual(expected_01_2021, result_to_dict["contraCheque"][0])
-
 
     def test_mppe_01_2021(self):
         self.maxDiff = None
@@ -191,7 +189,6 @@ class TestParser(unittest.TestCase):
         result_to_dict = MessageToDict(result_data)
 
         self.assertEqual(expected_01_2021, result_to_dict["contraCheque"][0])
-
 
     def test_mppe_12_2021(self):
         self.maxDiff = None
@@ -253,7 +250,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_01_2023, result_to_dict["contraCheque"][0])
 
-
     def test_mprj_01_2021(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -273,7 +269,7 @@ class TestParser(unittest.TestCase):
         result_to_dict = MessageToDict(result_data)
 
         self.assertEqual(expected_01_2021, result_to_dict["contraCheque"][0])
-    
+
     def test_mprj_10_2022(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -308,9 +304,112 @@ class TestParser(unittest.TestCase):
         dados = data.Data("2023", "05", "MPRJ", "src/output_test/sheets")
         dados = data.load(files, dados)
         result_data = parse(dados, "mprj/05/2023")
-        
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
         self.assertEqual(expected_05_2023, result_to_dict["contraCheque"][0])
-    
+
+    def test_mprj_06_2023(self):
+        self.maxDiff = None
+        # Json com a saida esperada
+        with open("src/output_test/expected/expected_mprj_06_2023.json", "r") as fp:
+            expected_06_2023 = json.load(fp)
+
+        files = [
+            "src/output_test/sheets/MPRJ-contracheques-06-2023.ods",
+            "src/output_test/sheets/MPRJ-indenizacoes-06-2023.ods",
+        ]
+
+        dados = data.Data("2023", "06", "MPRJ", "src/output_test/sheets")
+        dados = data.load(files, dados)
+        result_data = parse(dados, "mprj/06/2023")
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
+        self.assertEqual(expected_06_2023, result_to_dict["contraCheque"][0])
+
+    def test_mprj_07_2023(self):
+        self.maxDiff = None
+        # Json com a saida esperada
+        with open("src/output_test/expected/expected_mprj_07_2023.json", "r") as fp:
+            expected_07_2023 = json.load(fp)
+
+        files = [
+            "src/output_test/sheets/MPRJ-contracheques-07-2023.ods",
+            "src/output_test/sheets/MPRJ-indenizacoes-07-2023.ods",
+        ]
+
+        dados = data.Data("2023", "07", "MPRJ", "src/output_test/sheets")
+        dados = data.load(files, dados)
+        result_data = parse(dados, "mprj/07/2023")
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
+        self.assertEqual(expected_07_2023, result_to_dict["contraCheque"][0])
+
+    def test_mprj_08_2023(self):
+        self.maxDiff = None
+        # Json com a saida esperada
+        with open("src/output_test/expected/expected_mprj_08_2023.json", "r") as fp:
+            expected_08_2023 = json.load(fp)
+
+        files = [
+            "src/output_test/sheets/MPRJ-contracheques-08-2023.ods",
+            "src/output_test/sheets/MPRJ-indenizacoes-08-2023.ods",
+        ]
+
+        dados = data.Data("2023", "08", "MPRJ", "src/output_test/sheets")
+        dados = data.load(files, dados)
+        result_data = parse(dados, "mprj/08/2023")
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
+        self.assertEqual(expected_08_2023, result_to_dict["contraCheque"][0])
+
+    def test_mprj_09_2023(self):
+        self.maxDiff = None
+        # Json com a saida esperada
+        with open("src/output_test/expected/expected_mprj_09_2023.json", "r") as fp:
+            expected_09_2023 = json.load(fp)
+
+        files = [
+            "src/output_test/sheets/MPRJ-contracheques-09-2023.ods",
+            "src/output_test/sheets/MPRJ-indenizacoes-09-2023.ods",
+        ]
+
+        dados = data.Data("2023", "09", "MPRJ", "src/output_test/sheets")
+        dados = data.load(files, dados)
+        result_data = parse(dados, "mprj/09/2023")
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
+        self.assertEqual(expected_09_2023, result_to_dict["contraCheque"][0])
+
+    def test_mprj_10_2023(self):
+        self.maxDiff = None
+        # Json com a saida esperada
+        with open("src/output_test/expected/expected_mprj_10_2023.json", "r") as fp:
+            expected_10_2023 = json.load(fp)
+
+        files = [
+            "src/output_test/sheets/MPRJ-contracheques-10-2023.ods",
+            "src/output_test/sheets/MPRJ-indenizacoes-10-2023.ods",
+        ]
+
+        dados = data.Data("2023", "10", "MPRJ", "src/output_test/sheets")
+        dados = data.load(files, dados)
+        result_data = parse(dados, "mprj/10/2023")
+
+        # Converto o resultado do parser, em dict
+        result_to_dict = MessageToDict(result_data)
+
+        self.assertEqual(expected_10_2023, result_to_dict["contraCheque"][0])
+
     def test_mpsp_01_2022(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -331,23 +430,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_01_2022, result_to_dict["contraCheque"][0])
 
-    def test_mprj_06_2023(self):
-        self.maxDiff = None
-        # Json com a saida esperada
-        with open("src/output_test/expected/expected_mprj_06_2023.json", "r") as fp:
-            expected_06_2023 = json.load(fp)
-
-        files = [
-            "src/output_test/sheets/MPRJ-contracheques-06-2023.ods",
-            "src/output_test/sheets/MPRJ-indenizacoes-06-2023.ods",
-        ]
-
-        dados = data.Data("2023", "06", "MPRJ", "src/output_test/sheets")
-        dados = data.load(files, dados)
-        result_data = parse(dados, "mprj/06/2023")
-
-        self.assertEqual(expected_06_2023, result_to_dict["contraCheque"][0])
-    
     def test_mpsp_02_2022(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -367,23 +449,6 @@ class TestParser(unittest.TestCase):
         result_to_dict = MessageToDict(result_data)
 
         self.assertEqual(expected_02_2022, result_to_dict["contraCheque"][0])
-
-    def test_mprj_07_2023(self):
-        self.maxDiff = None
-        # Json com a saida esperada
-        with open("src/output_test/expected/expected_mprj_07_2023.json", "r") as fp:
-            expected_07_2023 = json.load(fp)
-
-        files = [
-            "src/output_test/sheets/MPRJ-contracheques-07-2023.ods",
-            "src/output_test/sheets/MPRJ-indenizacoes-07-2023.ods",
-        ]
-
-        dados = data.Data("2023", "07", "MPRJ", "src/output_test/sheets")
-        dados = data.load(files, dados)
-        result_data = parse(dados, "mprj/07/2023")
-
-        self.assertEqual(expected_07_2023, result_to_dict["contraCheque"][0])
 
     def test_mpsp_03_2022(self):
         self.maxDiff = None
@@ -405,23 +470,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_03_2022, result_to_dict["contraCheque"][0])
 
-    def test_mprj_08_2023(self):
-        self.maxDiff = None
-        # Json com a saida esperada
-        with open("src/output_test/expected/expected_mprj_08_2023.json", "r") as fp:
-            expected_08_2023 = json.load(fp)
-
-        files = [
-            "src/output_test/sheets/MPRJ-contracheques-08-2023.ods",
-            "src/output_test/sheets/MPRJ-indenizacoes-08-2023.ods",
-        ]
-
-        dados = data.Data("2023", "08", "MPRJ", "src/output_test/sheets")
-        dados = data.load(files, dados)
-        result_data = parse(dados, "mprj/08/2023")
-
-        self.assertEqual(expected_08_2023, result_to_dict["contraCheque"][0])
-
     def test_mpsp_08_2022(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -442,23 +490,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_08_2022, result_to_dict["contraCheque"][0])
 
-    def test_mprj_09_2023(self):
-        self.maxDiff = None
-        # Json com a saida esperada
-        with open("src/output_test/expected/expected_mprj_09_2023.json", "r") as fp:
-            expected_09_2023 = json.load(fp)
-
-        files = [
-            "src/output_test/sheets/MPRJ-contracheques-09-2023.ods",
-            "src/output_test/sheets/MPRJ-indenizacoes-09-2023.ods",
-        ]
-
-        dados = data.Data("2023", "09", "MPRJ", "src/output_test/sheets")
-        dados = data.load(files, dados)
-        result_data = parse(dados, "mprj/09/2023")
-
-        self.assertEqual(expected_09_2023, result_to_dict["contraCheque"][0])
-    
     def test_mpsp_01_2023(self):
         self.maxDiff = None
         # Json com a saida esperada
@@ -479,23 +510,6 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(expected_01_2023, result_to_dict["contraCheque"][0])
 
-    def test_mprj_10_2023(self):
-        self.maxDiff = None
-        # Json com a saida esperada
-        with open("src/output_test/expected/expected_mprj_10_2023.json", "r") as fp:
-            expected_10_2023 = json.load(fp)
-
-        files = [
-            "src/output_test/sheets/MPRJ-contracheques-10-2023.ods",
-            "src/output_test/sheets/MPRJ-indenizacoes-10-2023.ods",
-        ]
-
-        dados = data.Data("2023", "10", "MPRJ", "src/output_test/sheets")
-        dados = data.load(files, dados)
-        result_data = parse(dados, "mprj/10/2023")
-
-        self.assertEqual(expected_10_2023, result_to_dict["contraCheque"][0])
-    
     def test_mpsp_07_2023(self):
         self.maxDiff = None
         # Json com a saida esperada


### PR DESCRIPTION
- fui resolver um conflito pelo próprio github, posteriormente os testes não passaram e percebi que uma linha havia sido removida de algumas funções.
- corrigindo o problema e reorganizando os testes por órgão e ordem cronológica