### PR TITLE
corrigindo problema de remunerações negativas no MPRJ e MPPA

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -12,7 +12,14 @@ STATUS_INVALID_FILE = 5
 
 def _readXLS(file):
     try:
-        dt = pd.read_excel(file, engine="xlrd")
+        # A planilha de contracheques do MPPA traz a matrícula como float, 
+        # enquanto a planilha de indenizações traz do tipo string.
+        # Isso é um problema, considerando, principalmente, matrícula terminadas em 0
+        # Definimos que o tipo da coluna é string ainda na leitura
+        if 'mppa' in file.casefold():
+            dt = pd.read_excel(file, engine="xlrd", dtype={'Matrícula': str})
+        else:
+            dt = pd.read_excel(file, engine="xlrd")
         data = dt.to_numpy()
     except Exception as excep:
         print(f"Erro lendo as planilhas XLS ({file}): {excep}", file=sys.stderr)

--- a/src/headers_keys.py
+++ b/src/headers_keys.py
@@ -5,6 +5,7 @@ INDENIZACOES_MPRJ = "indenizacoes-mprj"
 INDENIZACOES_MPRJ_10_2022 = "indenizacoes-mprj-10-2022"
 INDENIZACOES_MPRJ_05_2023 = "indenizacoes-mprj-05-2023"
 INDENIZACOES_MPRJ_07_2023 = "indenizacoes-mprj-07-2023"
+INDENIZACOES_MPRJ_12_2023 = "indenizacoes-mprj-12-2023"
 CONTRACHEQUE_MPRN = "contracheque-mprn"
 INDENIZACOES_MPRN = "indenizacoes-mprn"
 CONTRACHEQUE_MPTO = "contracheque-mpto"
@@ -176,6 +177,21 @@ HEADERS = {
         "GRATIFICAÇÕES EVENTUAIS": 15,
         "INDENIZAÇÃO DE TRANSPORTE": 16,
         "PARCELAS PAGAS EM ATRASO": 17,
+    },
+    INDENIZACOES_MPRJ_12_2023: {
+        "AUXÍLIO-ALIMENTAÇÃO": 4,
+        "AUXÍLIO-EDUCAÇÃO": 5,
+        "AUXÍLIO-SAÚDE": 6,
+        "CONVERSÃO DE LICENÇA ESPECIAL/PRÊMIO": 7,
+        "INDENIZAÇÃO DE TRANSPORTE": 8,
+        "INDENIZAÇÃO POR LICENÇA NÃO GOZADA": 9,
+        "AUXÍLIO-ALIMENTAÇÃO": 10,
+        "AUXÍLIO-EDUCAÇÃO": 11,
+        "AUXÍLIO-SAÚDE": 12,
+        "DIFERENÇAS DE AUXÍLIOS": 13,
+        "GRATIFICAÇÕES EVENTUAIS": 14,
+        "INDENIZAÇÃO DE TRANSPORTE": 15,
+        "PARCELAS PAGAS EM ATRASO": 16,
     },
     CONTRACHEQUE_MPRN: {
         "REMUNERAÇÃO BÁSICA": {

--- a/src/parser.py
+++ b/src/parser.py
@@ -376,8 +376,10 @@ def get_mprj_header(year, month):
     elif year == 2023:
         if month in [5, 6, 9, 10]:
             header = "mprj-05-2023"
-        elif month in [7, 8]:
+        elif month in [7, 8, 11]:
             header = "mprj-07-2023"
+        elif month in [12]:
+            header = "mprj-12-2023"
 
     return header
 
@@ -525,8 +527,6 @@ def update_employees_mppa(data, employees):
 
     for row in data.indenizatorias:
         registration = row[0]
-        if type(registration) != str and not pd.isna(registration):
-            registration = str(int(registration))
 
         if registration in employees.keys():
             emp = employees[registration]


### PR DESCRIPTION
- O problema do MPRJ ocorre devido arquivos estarem "quebrados", a solução foi salvar novamente os arquivos no drive
- Além disso, identifiquei que o MPRJ mudou novamente sua estrutura de dados no mês de dezembro de 2023
- O problema do MPPA ocorre devido inconsistência no tipo das colunas no contracheque e indenização.
  - por exemplo, a matrícula `999.3100` na planilha de indenizações, escrita corretamente como string, era lida na planilha de contracheques como float, i.e. `999.31`, o que impedia o correto mapeamento das verbas de cada membro.